### PR TITLE
Refresh token as part of access token json file

### DIFF
--- a/commands/GoogleController.php
+++ b/commands/GoogleController.php
@@ -200,6 +200,7 @@ class GoogleController extends Controller
         $client = new Google_Client();
         $client->setAuthConfigFile($this->clientSecretPath);
         $client->setAccessType('offline');
+        $client->setApprovalPrompt('force');
         $client->setScopes(implode(' ', $scopes));
 
         // Request authorization from the user.


### PR DESCRIPTION
Google Api no longer returns refresh_token as part of the json file.
This answer shows how to resolve the issue
https://stackoverflow.com/a/43412638/4923688
Tried it and it worked as earlier